### PR TITLE
std.math.lround only doesn't crash on posix

### DIFF
--- a/source/xlsxreader.d
+++ b/source/xlsxreader.d
@@ -497,7 +497,7 @@ unittest {
 }
 
 TimeOfDay doubleToTimeOfDay(double s) {
-	import std.math : lround;
+	import core.stdc.math : lround;
 	double secs = (24.0 * 60.0 * 60.0) * s;
 
 	// TODO not one-hundred my lround is needed


### PR DESCRIPTION
yes, std.math.lround is actually core.stdc.math.llroundl, but you're taking a double and then trying to get to int, so i think lround is fine.